### PR TITLE
Update Tracelens extension methods to allow specifying public ports

### DIFF
--- a/Aspire/TraceLens.Aspire/TraceLens.Aspire.csproj
+++ b/Aspire/TraceLens.Aspire/TraceLens.Aspire.csproj
@@ -22,10 +22,10 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.6.24214.1" />
+      <PackageReference Include="Aspire.Hosting" Version="8.2.1" />
       <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0-preview.6.24214.1" />
+        <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.2.1" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Aspire/TraceLens.Aspire/TraceLensExtensions.cs
+++ b/Aspire/TraceLens.Aspire/TraceLensExtensions.cs
@@ -11,8 +11,8 @@ public static class TraceLensExtensions
 {
     public static ContainerResource AddTraceLens(
         this IDistributedApplicationBuilder distributedApplicationBuilder, 
-        int? tracelensPort = 5001, 
-        int? plantUmlPort = 8080)
+        int tracelensPort = 5001, 
+        int plantUmlPort = 8080)
     {
         var tracelensDb = distributedApplicationBuilder
             .AddPostgres("tracelenspgsql")

--- a/Aspire/TraceLens.Aspire/TraceLensExtensions.cs
+++ b/Aspire/TraceLens.Aspire/TraceLensExtensions.cs
@@ -9,18 +9,25 @@ namespace TraceLens.Aspire;
 [PublicAPI]
 public static class TraceLensExtensions
 {
-    public static ContainerResource AddTraceLens(this IDistributedApplicationBuilder distributedApplicationBuilder)
+    public static ContainerResource AddTraceLens(
+        this IDistributedApplicationBuilder distributedApplicationBuilder, 
+        int? tracelensPort = 5001, 
+        int? plantUmlPort = 8080)
     {
-        var tracelensDb = distributedApplicationBuilder.AddPostgres("tracelenspgsql").AddDatabase("tracelensdb");
+        var tracelensDb = distributedApplicationBuilder
+            .AddPostgres("tracelenspgsql")
+            .AddDatabase("tracelensdb");
 
-        var plantUml = distributedApplicationBuilder.AddContainer("plantuml", "plantuml/plantuml-server", tag: "tomcat")
-            .WithHttpEndpoint(8080, name: "plantuml");
+        var plantUml = distributedApplicationBuilder
+            .AddContainer("plantuml", "plantuml/plantuml-server", tag: "tomcat")
+            .WithHttpEndpoint(port: plantUmlPort, targetPort: 8080, name: "plantuml");
 
         distributedApplicationBuilder.Services.TryAddLifecycleHook<EnvironmentVariableHook>();
         
-        var tracelens = distributedApplicationBuilder.AddContainer("tracelens", "rogeralsing/tracelens")
-            .WithHttpEndpoint(5001, name: "tracelens")
-            .WithHttpEndpoint(4317, name: "otel")
+        var tracelens = distributedApplicationBuilder
+            .AddContainer("tracelens", "rogeralsing/tracelens")
+            .WithHttpEndpoint(port: tracelensPort, targetPort: 5001, name: "tracelens")
+            .WithHttpEndpoint(port: 4317, targetPort: 4317, name: "otel")
             .WithEnvironment("PlantUml__RemoteUrl",plantUml.GetEndpoint("plantuml"))
             .WithReference(tracelensDb, "DefaultConnection");
         


### PR DESCRIPTION
- Updated Aspire Hosting libraries to 8.2.1

- Updated AddTracelens extension method to allow specifying public ports for Tracelens and PlantUML in case the defaults are already in use by other containers

- Explicitly setting targetPort in WithHttpEndpoint calls